### PR TITLE
Encode ingredients individually for filter queries

### DIFF
--- a/src/features/recipes/api.ts
+++ b/src/features/recipes/api.ts
@@ -6,8 +6,11 @@ const DEFAULT_HEADERS: HeadersInit = {
   Accept: 'application/json',
 }
 
+/**
+ * Encode ingredient values individually while preserving comma separators required by the API.
+ */
 function buildIngredientQuery(ingredients: string[]): string {
-  return encodeURIComponent(ingredients.join(','))
+  return ingredients.map((item) => encodeURIComponent(item)).join(',')
 }
 
 async function request<T>(url: string, signal?: AbortSignal): Promise<T> {


### PR DESCRIPTION
## Summary
- encode each ingredient individually so the filter API keeps comma separators between values
- document the ingredient encoding behavior at the helper level to guard against regressions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca1919f0c883308ee411caaad92310