### PR TITLE
Improve Korean recipe search accuracy and tip handling

### DIFF
--- a/src/components/RecipeCard.tsx
+++ b/src/components/RecipeCard.tsx
@@ -106,6 +106,12 @@ export function RecipeCard({ recipe, onReroll, isLoading }: RecipeCardProps) {
             상세 조리 설명이 제공되지 않은 레시피예요. 원문 링크를 참고해 주세요.
           </p>
         )}
+        {recipe.tip ? (
+          <p className="rounded-xl border border-amber-200 bg-amber-50/70 p-4 text-sm leading-relaxed text-slate-700">
+            <span className="font-semibold text-amber-700">영양 팁</span>
+            <span className="ml-2 text-slate-700">{recipe.tip}</span>
+          </p>
+        ) : null}
       </section>
 
       <footer className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">

--- a/src/features/recipes/api.test.ts
+++ b/src/features/recipes/api.test.ts
@@ -1,8 +1,17 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { filterByIngredients } from './api'
+import {
+  fetchKoreanRecipes,
+  fetchKoreanRecipesByIngredients,
+  toMealDetailFromKorean,
+  toMealSummaryFromKorean,
+} from './koreanApi'
+import { toRecipe } from './utils'
 import type { FilterResponse, MealSummary } from './types'
+import type { KoreanRecipeRaw } from './koreanApi'
 
 const FILTER_ENDPOINT = 'https://www.themealdb.com/api/json/v1/1/filter.php?i='
+const KOREAN_ENDPOINT = 'https://apis.data.go.kr/1390804/AgriFood/FdFood/getKoreanRecipe01'
 
 type ResponseMap = Record<string, FilterResponse>
 type MockResponse = {
@@ -111,5 +120,202 @@ describe('filterByIngredients', () => {
     const result = await filterByIngredients(['chicken', 'onion'])
 
     expect(result).toBeNull()
+  })
+})
+
+describe('fetchKoreanRecipes', () => {
+  const sampleRecipe: KoreanRecipeRaw = {
+    RCP_SEQ: '100',
+    RCP_NM: '비빔밥',
+    ATT_FILE_NO_MAIN: 'https://example.com/thumb.jpg',
+    RCP_PARTS_DTLS: '주재료: 쌀 1컵, 고사리 50g\n양념: 고추장 2큰술',
+    MANUAL01: '1. 재료를 손질한다.',
+    MANUAL02: '2. 비빔밥을 완성한다.',
+    RCP_NA_TIP: '고추장은 기호에 따라 양을 조절하세요.',
+  }
+
+  it('builds the API request with the provided search parameters', async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ data: [sampleRecipe] }),
+    }))
+
+    vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch)
+
+    const signal = new AbortController().signal
+    const result = await fetchKoreanRecipes({
+      serviceKey: 'test-key',
+      RCP_NM: '비빔밥',
+      RCP_PARTS_DTLS: '고사리,고추장',
+      pageNo: 2,
+      numOfRows: 5,
+      signal,
+    })
+
+    expect(result).toEqual([sampleRecipe])
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    const [requestedUrl, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(init?.headers).toEqual({ Accept: 'application/json' })
+    expect(init?.signal).toBe(signal)
+
+    const url = new URL(requestedUrl)
+    expect(url.origin + url.pathname).toBe(KOREAN_ENDPOINT)
+    expect(url.searchParams.get('serviceKey')).toBe('test-key')
+    expect(url.searchParams.get('RCP_NM')).toBe('비빔밥')
+    expect(url.searchParams.get('RCP_PARTS_DTLS')).toBe('고사리,고추장')
+    expect(url.searchParams.get('pageNo')).toBe('2')
+    expect(url.searchParams.get('numOfRows')).toBe('5')
+    expect(url.searchParams.get('type')).toBe('json')
+  })
+
+  it('extracts recipes from nested body payloads', async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ body: { items: { item: sampleRecipe } } }),
+    }))
+
+    vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch)
+
+    const result = await fetchKoreanRecipes({ serviceKey: 'test-key' })
+    expect(result).toEqual([sampleRecipe])
+  })
+
+  it('normalizes nested API responses and maps to Meal types', () => {
+    const detail = toMealDetailFromKorean(sampleRecipe)
+    const summary = toMealSummaryFromKorean(sampleRecipe)
+
+    expect(summary).toEqual({
+      idMeal: '100',
+      strMeal: '비빔밥',
+      strMealThumb: 'https://example.com/thumb.jpg',
+    })
+
+    expect(detail).toMatchObject({
+      idMeal: '100',
+      strMeal: '비빔밥',
+      strInstructions: '1. 재료를 손질한다.\n2. 비빔밥을 완성한다.',
+    })
+    expect(detail.strSource).toBeNull()
+    expect(detail.strTip).toBe('고추장은 기호에 따라 양을 조절하세요.')
+    expect(detail.strIngredient1).toBe('쌀 1컵')
+    expect(detail.strIngredient2).toBe('고사리 50g')
+    expect(detail.strIngredient3).toBe('고추장 2큰술')
+
+    const recipe = toRecipe(detail)
+    expect(recipe.ingredients.map((item) => item.name)).toEqual([
+      '쌀 1컵',
+      '고사리 50g',
+      '고추장 2큰술',
+    ])
+    expect(recipe.instructions).toEqual(['1. 재료를 손질한다.', '2. 비빔밥을 완성한다.'])
+    expect(recipe.sourceUrl).toBeUndefined()
+    expect(recipe.tip).toBe('고추장은 기호에 따라 양을 조절하세요.')
+  })
+
+  it('treats nutrition tips that are URLs as source links', () => {
+    const recipeWithUrl: KoreanRecipeRaw = {
+      ...sampleRecipe,
+      RCP_SEQ: '200',
+      RCP_NM: '비빔밥 레시피',
+      RCP_NA_TIP: 'https://example.com/recipe',
+    }
+
+    const detail = toMealDetailFromKorean(recipeWithUrl)
+    expect(detail.strSource).toBe('https://example.com/recipe')
+    expect(detail.strTip).toBeUndefined()
+
+    const recipe = toRecipe(detail)
+    expect(recipe.sourceUrl).toBe('https://example.com/recipe')
+    expect(recipe.tip).toBeUndefined()
+  })
+})
+
+describe('fetchKoreanRecipesByIngredients', () => {
+  const baseRecipe = (overrides: Partial<KoreanRecipeRaw>): KoreanRecipeRaw => ({
+    RCP_SEQ: '1',
+    RCP_NM: '불고기',
+    RCP_PARTS_DTLS: '소고기 200g, 양파 1/2개, 간장 2큰술',
+    MANUAL01: '1. 재료를 준비한다.',
+    ...overrides,
+  })
+
+  it('fetches each ingredient separately and intersects the recipe list', async () => {
+    const responses: Record<string, KoreanRecipeRaw[]> = {
+      소고기: [
+        baseRecipe({ RCP_SEQ: '10', RCP_PARTS_DTLS: '소고기 200g, 양파 1/2개' }),
+        baseRecipe({ RCP_SEQ: '11', RCP_PARTS_DTLS: '소고기 300g, 버섯 1줌' }),
+      ],
+      양파: [baseRecipe({ RCP_SEQ: '10', RCP_PARTS_DTLS: '소고기 200g, 양파 1/2개' })],
+    }
+
+    const fetchMock = vi.fn(async (input: string | URL) => {
+      const url = new URL(typeof input === 'string' ? input : input.toString())
+      const ingredient = url.searchParams.get('RCP_PARTS_DTLS') ?? ''
+      const data = responses[ingredient] ?? []
+      return {
+        ok: true,
+        json: async () => ({ data }),
+      }
+    })
+
+    vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch)
+
+    const result = await fetchKoreanRecipesByIngredients({
+      serviceKey: 'test-key',
+      ingredients: ['소고기', '양파'],
+    })
+
+    expect(result).toHaveLength(1)
+    expect(result[0]?.RCP_SEQ).toBe('10')
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('returns an empty array when any ingredient has no matches', async () => {
+    const fetchMock = vi.fn(async (input: string | URL) => {
+      const url = new URL(typeof input === 'string' ? input : input.toString())
+      const ingredient = url.searchParams.get('RCP_PARTS_DTLS') ?? ''
+      const data = ingredient === '소고기' ? [baseRecipe({ RCP_SEQ: '20' })] : []
+      return {
+        ok: true,
+        json: async () => ({ data }),
+      }
+    })
+
+    vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch)
+
+    const result = await fetchKoreanRecipesByIngredients({
+      serviceKey: 'test-key',
+      ingredients: ['소고기', '마늘'],
+    })
+
+    expect(result).toEqual([])
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('filters out recipes that do not actually contain every ingredient', async () => {
+    const fetchMock = vi.fn(async (input: string | URL) => {
+      const url = new URL(typeof input === 'string' ? input : input.toString())
+      const ingredient = url.searchParams.get('RCP_PARTS_DTLS') ?? ''
+      const data = [
+        baseRecipe({
+          RCP_SEQ: '30',
+          RCP_PARTS_DTLS: ingredient === '고추장' ? '된장 1큰술, 간장 1큰술' : '고추장 2큰술, 된장 1큰술',
+        }),
+      ]
+      return {
+        ok: true,
+        json: async () => ({ data }),
+      }
+    })
+
+    vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch)
+
+    const result = await fetchKoreanRecipesByIngredients({
+      serviceKey: 'test-key',
+      ingredients: ['고추장', '된장'],
+    })
+
+    expect(result).toHaveLength(0)
   })
 })

--- a/src/features/recipes/koreanApi.ts
+++ b/src/features/recipes/koreanApi.ts
@@ -1,0 +1,247 @@
+import type { MealDetailRaw, MealSummary } from './types'
+
+const BASE_URL = 'https://apis.data.go.kr/1390804/AgriFood/FdFood/getKoreanRecipe01'
+
+const DEFAULT_HEADERS: HeadersInit = {
+  Accept: 'application/json',
+}
+
+const MANUAL_KEYS = Array.from({ length: 20 }, (_, index) =>
+  `MANUAL${String(index + 1).padStart(2, '0')}`,
+)
+
+function normalizeIngredientList(ingredients: string[]): string[] {
+  return Array.from(
+    new Set(
+      ingredients
+        .map((item) => item.trim())
+        .filter(Boolean),
+    ),
+  )
+}
+
+export type KoreanRecipeRaw = {
+  RCP_SEQ: string
+  RCP_NM: string
+  RCP_PARTS_DTLS?: string | null
+  ATT_FILE_NO_MAIN?: string | null
+  ATT_FILE_NO_MK?: string | null
+  RCP_NA_TIP?: string | null
+  [key: string]: string | null | undefined
+}
+
+export type FetchKoreanRecipesParams = {
+  serviceKey: string
+  RCP_NM?: string
+  RCP_PARTS_DTLS?: string
+  pageNo?: number
+  numOfRows?: number
+  signal?: AbortSignal
+}
+
+type KoreanApiResponse = {
+  data?: KoreanRecipeRaw[]
+  currentCount?: number
+  getKoreanRecipe01?: { item?: KoreanRecipeRaw[]; row?: KoreanRecipeRaw[] }
+  body?: { items?: { item?: KoreanRecipeRaw | KoreanRecipeRaw[] } }
+}
+
+function buildUrl({
+  serviceKey,
+  RCP_NM,
+  RCP_PARTS_DTLS,
+  pageNo = 1,
+  numOfRows = 100,
+}: FetchKoreanRecipesParams): string {
+  const params = new URLSearchParams({
+    serviceKey,
+    pageNo: String(pageNo),
+    numOfRows: String(numOfRows),
+    type: 'json',
+  })
+
+  if (RCP_NM) {
+    params.set('RCP_NM', RCP_NM)
+  }
+
+  if (RCP_PARTS_DTLS) {
+    params.set('RCP_PARTS_DTLS', RCP_PARTS_DTLS)
+  }
+
+  return `${BASE_URL}?${params.toString()}`
+}
+
+function extractRecipes(body: KoreanApiResponse): KoreanRecipeRaw[] {
+  if (Array.isArray(body.data)) {
+    return body.data
+  }
+
+  const getKoreanRecipe01 = body.getKoreanRecipe01
+  if (getKoreanRecipe01) {
+    if (Array.isArray(getKoreanRecipe01.item)) {
+      return getKoreanRecipe01.item
+    }
+    if (Array.isArray(getKoreanRecipe01.row)) {
+      return getKoreanRecipe01.row
+    }
+  }
+
+  const items = body.body?.items?.item
+  if (Array.isArray(items)) {
+    return items
+  }
+  if (items) {
+    return [items]
+  }
+
+  return []
+}
+
+export async function fetchKoreanRecipes({ signal, ...params }: FetchKoreanRecipesParams): Promise<KoreanRecipeRaw[]> {
+  const url = buildUrl(params)
+  const res = await fetch(url, { headers: DEFAULT_HEADERS, signal })
+
+  if (!res.ok) {
+    throw new Error('한식 레시피 정보를 불러올 수 없어요.')
+  }
+
+  const data = (await res.json()) as KoreanApiResponse
+  return extractRecipes(data)
+}
+
+function parseParts(parts: string | null | undefined): string[] {
+  if (!parts) return []
+
+  return parts
+    .split(/\r?\n+/)
+    .map((line) => line.split(':').slice(1).join(':').trim() || line.trim())
+    .flatMap((line) => line.split(/[;,]/))
+    .map((item) => item.trim())
+    .filter(Boolean)
+}
+
+function mergeManuals(recipe: KoreanRecipeRaw): string {
+  return MANUAL_KEYS.map((key) => recipe[key])
+    .map((value) => (typeof value === 'string' ? value.trim() : ''))
+    .filter(Boolean)
+    .join('\n')
+}
+
+export function toMealSummaryFromKorean(recipe: KoreanRecipeRaw): MealSummary {
+  return {
+    idMeal: recipe.RCP_SEQ,
+    strMeal: recipe.RCP_NM,
+    strMealThumb: recipe.ATT_FILE_NO_MAIN || recipe.ATT_FILE_NO_MK || '',
+  }
+}
+
+function extractSourceAndTip(value: string | null | undefined): {
+  source: string | null
+  tip: string | null
+} {
+  if (!value) {
+    return { source: null, tip: null }
+  }
+
+  const trimmed = value.trim()
+  if (!trimmed) {
+    return { source: null, tip: null }
+  }
+
+  try {
+    const url = new URL(trimmed)
+    if (url.protocol === 'http:' || url.protocol === 'https:') {
+      return { source: url.toString(), tip: null }
+    }
+  } catch (error) {
+    void error
+  }
+
+  return { source: null, tip: trimmed }
+}
+
+function recipeIncludesAllIngredients(recipe: KoreanRecipeRaw, ingredients: string[]): boolean {
+  if (ingredients.length === 0) return true
+
+  const normalizedParts = parseParts(recipe.RCP_PARTS_DTLS).map((part) => part.toLowerCase())
+  return ingredients.every((ingredient) =>
+    normalizedParts.some((part) => part.includes(ingredient.toLowerCase())),
+  )
+}
+
+export function toMealDetailFromKorean(recipe: KoreanRecipeRaw): MealDetailRaw {
+  const { source, tip } = extractSourceAndTip(recipe.RCP_NA_TIP)
+  const detail: MealDetailRaw = {
+    idMeal: recipe.RCP_SEQ,
+    strMeal: recipe.RCP_NM,
+    strMealThumb: recipe.ATT_FILE_NO_MAIN || recipe.ATT_FILE_NO_MK || '',
+    strInstructions: mergeManuals(recipe),
+    strSource: source,
+    strYoutube: null,
+  }
+
+  if (tip) {
+    detail.strTip = tip
+  }
+
+  const ingredients = parseParts(recipe.RCP_PARTS_DTLS)
+  ingredients.forEach((value, index) => {
+    const key = index + 1
+    detail[`strIngredient${key}`] = value
+    detail[`strMeasure${key}`] = ''
+  })
+
+  return detail
+}
+
+export async function fetchKoreanRecipesByIngredients({
+  serviceKey,
+  ingredients,
+  signal,
+}: {
+  serviceKey: string
+  ingredients: string[]
+  signal?: AbortSignal
+}): Promise<KoreanRecipeRaw[]> {
+  const uniqueIngredients = normalizeIngredientList(ingredients)
+  if (uniqueIngredients.length === 0) {
+    return []
+  }
+
+  const lists = await Promise.all(
+    uniqueIngredients.map((ingredient) =>
+      fetchKoreanRecipes({
+        serviceKey,
+        RCP_PARTS_DTLS: ingredient,
+        signal,
+      }),
+    ),
+  )
+
+  if (lists.some((list) => list.length === 0)) {
+    return []
+  }
+
+  const counts = new Map<string, number>()
+  const recipeMap = new Map<string, KoreanRecipeRaw>()
+
+  lists.forEach((list) => {
+    const seen = new Set<string>()
+    list.forEach((recipe) => {
+      const id = recipe.RCP_SEQ
+      if (!recipeMap.has(id)) {
+        recipeMap.set(id, recipe)
+      }
+      if (!seen.has(id)) {
+        seen.add(id)
+        counts.set(id, (counts.get(id) ?? 0) + 1)
+      }
+    })
+  })
+
+  return Array.from(recipeMap.values()).filter(
+    (recipe) =>
+      counts.get(recipe.RCP_SEQ) === uniqueIngredients.length &&
+      recipeIncludesAllIngredients(recipe, uniqueIngredients),
+  )
+}

--- a/src/features/recipes/store.ts
+++ b/src/features/recipes/store.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
 import { filterByIngredients, lookupById } from './api'
+import { fetchKoreanRecipesByIngredients, toMealDetailFromKorean } from './koreanApi'
 import { toRecipe } from './utils'
 import type { Recipe } from './types'
 
@@ -29,6 +30,8 @@ function isAbortError(error: unknown): boolean {
   return error instanceof Error && error.name === 'AbortError'
 }
 
+const KOREAN_SERVICE_KEY = import.meta.env.VITE_KOREAN_RECIPES_SERVICE_KEY
+
 export const useRecipeStore = create<State>((set, get) => {
   let listController: AbortController | null = null
   let detailController: AbortController | null = null
@@ -41,6 +44,12 @@ export const useRecipeStore = create<State>((set, get) => {
     set({ status: 'loadingList', error: null, recipe: null })
 
     try {
+      const koreanRecipe = await tryFetchKoreanRecipe(ingredients, listController.signal)
+      if (koreanRecipe) {
+        set({ status: 'success', recipe: koreanRecipe })
+        return
+      }
+
       const list = await filterByIngredients(ingredients, listController.signal)
 
       if (!list || list.length === 0) {
@@ -61,6 +70,35 @@ export const useRecipeStore = create<State>((set, get) => {
     } finally {
       listController = null
       detailController = null
+    }
+  }
+
+  async function tryFetchKoreanRecipe(
+    ingredients: string[],
+    signal: AbortSignal,
+  ): Promise<Recipe | null> {
+    if (!KOREAN_SERVICE_KEY) {
+      return null
+    }
+
+    try {
+      const recipeList = await fetchKoreanRecipesByIngredients({
+        serviceKey: KOREAN_SERVICE_KEY,
+        ingredients,
+        signal,
+      })
+
+      if (recipeList.length === 0) {
+        return null
+      }
+
+      const selected = toMealDetailFromKorean(pickRandom(recipeList))
+      return toRecipe(selected)
+    } catch (error) {
+      if (isAbortError(error)) {
+        throw error
+      }
+      return null
     }
   }
 

--- a/src/features/recipes/types.ts
+++ b/src/features/recipes/types.ts
@@ -15,6 +15,7 @@ export type MealDetailRaw = {
   strInstructions: string
   strSource: string | null
   strYoutube: string | null
+  strTip?: string | null
   [key: string]: string | null
 }
 
@@ -35,4 +36,5 @@ export type Recipe = {
   ingredients: Ingredient[]
   sourceUrl?: string
   youtubeUrl?: string
+  tip?: string
 }

--- a/src/features/recipes/utils.ts
+++ b/src/features/recipes/utils.ts
@@ -30,5 +30,6 @@ export function toRecipe(raw: MealDetailRaw): Recipe {
     ingredients: normalizeIngredients(raw),
     sourceUrl: raw.strSource || undefined,
     youtubeUrl: raw.strYoutube || undefined,
+    tip: raw.strTip?.trim() ? raw.strTip.trim() : undefined,
   }
 }

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_KOREAN_RECIPES_SERVICE_KEY?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}


### PR DESCRIPTION
## Summary
- ensure Korean nutrition tips only populate the source URL when they are valid links and expose the remaining text as a recipe tip
- add a helper to query the Korean API per ingredient, intersect the results, and update the store to rely on the new flow before falling back to TheMealDB
- surface optional nutrition tips in the recipe card and expand unit tests for the adapter and intersection logic

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca256ec7188330b00e540670ff2c56